### PR TITLE
Fixed User Warning

### DIFF
--- a/src/TatraPay/Message/CompletePurchaseRequest.php
+++ b/src/TatraPay/Message/CompletePurchaseRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\Tatrapay\Message;
+namespace Omnipay\TatraPay\Message;
 
 use Omnipay\Common\Currency;
 use Omnipay\Common\Exception\InvalidRequestException;

--- a/src/TatraPay/Message/CompletePurchaseResponse.php
+++ b/src/TatraPay/Message/CompletePurchaseResponse.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace Omnipay\Tatrapay\Message;
+namespace Omnipay\TatraPay\Message;
 
 use Omnipay\Common\Message\AbstractResponse;
-use Omnipay\Common\Message\RequestInterface;
 
 class CompletePurchaseResponse extends AbstractResponse
 {

--- a/src/TatraPay/Message/PurchaseResponse.php
+++ b/src/TatraPay/Message/PurchaseResponse.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Omnipay\Tatrapay\Message;
+namespace Omnipay\TatraPay\Message;
 
 use Omnipay\Common\Message\AbstractResponse;
 use Omnipay\Common\Message\RedirectResponseInterface;


### PR DESCRIPTION
Case mismatch on class name 'Omnipay\TatraPay\Message\PurchaseResponse', correct name is 'Omnipay\Tatrapay\Message\PurchaseResponse'.