### PR TITLE
Changing hardcoded IPs of Teleplatba SOAP to URL provided by J. Nadova.

### DIFF
--- a/src/ComfortPay/comfortpay.wsdl
+++ b/src/ComfortPay/comfortpay.wsdl
@@ -338,11 +338,8 @@
     <service name="TBTelePlatba">
         <documentation>TBTelePlatba Web Service - interface to TB Virtual Pos </documentation>
         <port name="ssl" binding="tns:TBTelePlatbaBind">
-            <!-- Master server -->
-            <SOAP:address location="https://213.81.202.67:25001"/>
-          
-            <!-- Backup server -->
-            <!-- <SOAP:address location="https://213.215.88.67:25001"/> -->
+            <!-- Load balancer for master and backup servers -->
+            <SOAP:address location="https://comfortpay.tatrabanka.sk:25001"/>
         </port>
     </service>
 


### PR DESCRIPTION
The change is based on following email from Tatrabanka.

  Vážení klienti,

  dovoľujem si Vás informovať, že v rámci služby ComfortPay sme pre Vás
  v rámci opakovaných platieb sprístupnili možnosť konektovať sa priamo
  na endpoint https://comfortpay.tatrabanka.sk:25001

  V súčasnosti spojenie prebieha na IP adresy Tatra banky:

  primárna: 213.81.202.67 port 25001
  záložná:  213.215.88.67, port 25001

  Spojenie priamo na https://comfortpay.tatrabanka.sk:25001 bolo
  v špecifikácii uvedené, avšak reálne nebolo funkčné. Konekcia priamo
  na tento endpoint zabezpečí plynulú a neprerušenú prevádzku služby
  v prípade nedostupnosti jednej z lokalít.

  Prosím, pokúste sa konektnúť na hore uvedený endpoint.

  V prípade problémov ma prosím kontaktujte.

  Ďakujem Vám za spoluprácu

  Pekný deň
  Jana Naďová