### PR TITLE
Fix renamed ResponseClass in ChargeRequest

### DIFF
--- a/src/ComfortPay/Message/ChargeRequest.php
+++ b/src/ComfortPay/Message/ChargeRequest.php
@@ -152,12 +152,12 @@ class ChargeRequest extends AbstractSoapRequest
     {
         if ($this->getTestmode()) {
             if ((int)$this->getReferedCardId() % 2 == 0) {
-                return $this->response = new ChargeResponse(
+                return $this->response = new CardTransactionResponse(
                     $this,
                     ['transactionId' => $data['transactionId'], 'transactionStatus' => '02', 'transactionApproval' => '123']
                 );
             }
-            return $this->response = new ChargeResponse(
+            return $this->response = new CardTransactionResponse(
                 $this,
                 ['transactionId' => $data['transactionId'], 'transactionStatus' => '00', 'transactionApproval' => '123']
             );


### PR DESCRIPTION
Issue: PaymentsSimulator (test mode) is not working. Exception is thrown:

```
Error: Class `Omnipay\ComfortPay\Message\ChargeResponse` not found
```

Fix: Two `ChargeResponse` occurences renamed to `CardTransactionResponse`
in test mode block within `Omnipay\ComfortPay\Message\ChargeRequest`.