### PR TITLE
Added authorize and cancelAuthorize method

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -13,6 +13,7 @@ jobs:
         with:
           php-version: '7.1'
           ini-values: post_max_size=256M, max_execution_time=180
+          extensions: soap
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Removed travis support
  - Added support for github workflows
  - Fix syntax errors
+ - Add methods for authorization and cancel authorization
 
 ## [4.0.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
  - Added CardPay tests
  - Removed travis support
  - Added support for github workflows
+ - Fix syntax errors
 
 ## [4.0.0]
 

--- a/src/CardPay/Gateway.php
+++ b/src/CardPay/Gateway.php
@@ -39,6 +39,11 @@ class Gateway extends AbstractGateway
         return $this->setParameter('sharedSecret', $value);
     }
 
+    public function getDefaultHttpClient()
+    {
+        return parent::getDefaultHttpClient();
+    }
+
     public function purchase(array $parameters = array())
     {
         return $this->createRequest(\Omnipay\CardPay\Message\PurchaseRequest::class, $parameters);
@@ -47,5 +52,20 @@ class Gateway extends AbstractGateway
     public function completePurchase(array $parameters = array())
     {
         return $this->createRequest(\Omnipay\CardPay\Message\CompletePurchaseRequest::class, $parameters);
+    }
+
+    public function authorize(array $parameters = array())
+    {
+        return $this->createRequest(\Omnipay\CardPay\Message\AuthorizeRequest::class, $parameters);
+    }
+
+    public function completeAuthorize(array $parameters = array())
+    {
+        return $this->createRequest(\Omnipay\CardPay\Message\CompleteAuthorizeRequest::class, $parameters);
+    }
+
+    public function cancelAuthorize(array $parameters = array())
+    {
+        return $this->createRequest(\Omnipay\CardPay\Message\CancelAuthorizeRequest::class, $parameters);
     }
 }

--- a/src/CardPay/Gateway.php
+++ b/src/CardPay/Gateway.php
@@ -39,11 +39,6 @@ class Gateway extends AbstractGateway
         return $this->setParameter('sharedSecret', $value);
     }
 
-    public function getDefaultHttpClient()
-    {
-        return parent::getDefaultHttpClient();
-    }
-
     public function purchase(array $parameters = array())
     {
         return $this->createRequest(\Omnipay\CardPay\Message\PurchaseRequest::class, $parameters);

--- a/src/CardPay/Message/AuthorizeRequest.php
+++ b/src/CardPay/Message/AuthorizeRequest.php
@@ -1,0 +1,305 @@
+<?php
+
+namespace Omnipay\CardPay\Message;
+
+use Money\Currencies\ISOCurrencies;
+use Money\Currency;
+use Omnipay\Core\Message\AbstractRequest;
+use Omnipay\Core\Sign\HmacSign;
+
+class AuthorizeRequest extends AbstractRequest
+{
+    const TXN_VALUE = 'PA';
+
+    public function initialize(array $parameters = array())
+    {
+        parent::initialize($parameters);
+
+        $this->setTimestamp(gmdate('dmYHis'));
+        if (isset($_SERVER['REMOTE_ADDR'])) {
+            $this->setIpc($_SERVER['REMOTE_ADDR']);
+        }
+        return $this;
+    }
+
+    public function getIpc()
+    {
+        return $this->getParameter('ipc');
+    }
+
+    public function setIpc($value)
+    {
+        return $this->setParameter('ipc', $value);
+    }
+
+    public function getName()
+    {
+        return $this->getParameter('name');
+    }
+
+    public function setName($value)
+    {
+        return $this->setParameter('name', $value);
+    }
+
+    public function setTpay($value)
+    {
+        return $this->setParameter('tpay', $value);
+    }
+
+    public function getTpay()
+    {
+        return $this->getParameter('tpay');
+    }
+
+    public function getTxn()
+    {
+        return static::TXN_VALUE;
+    }
+
+    public function getE2E()
+    {
+        return $this->getParameter('E2E');
+    }
+
+    public function setE2E($value)
+    {
+        return $this->setParameter('E2E', $value);
+    }
+
+    public function getCid()
+    {
+        return $this->getParameter('CID');
+    }
+
+    public function setCid($value)
+    {
+        return $this->setParameter('CID', $value);
+    }
+
+    public function getEcid()
+    {
+        return $this->getParameter('ECID');
+    }
+
+    public function setEcid($value)
+    {
+        return $this->setParameter('ECID', $value);
+    }
+
+    public function getTdsCardholder()
+    {
+        return $this->getParameter('E2E');
+    }
+
+    public function setTdsCardholder($value)
+    {
+        return $this->setParameter('E2E', $value);
+    }
+
+    public function getTdsEmail()
+    {
+        return $this->getParameter('TDS_EMAIL');
+    }
+
+    public function setTdsEmail($value)
+    {
+        return $this->setParameter('TDS_EMAIL', $value);
+    }
+
+    public function getTdsMobilePhone()
+    {
+        return $this->getParameter('TDS_MOBILE_PHONE');
+    }
+
+    public function setTdsMobilePhone($value)
+    {
+        return $this->setParameter('TDS_MOBILE_PHONE', $value);
+    }
+
+    public function getTdsBillCity()
+    {
+        return $this->getParameter('TDS_BILL_CITY');
+    }
+
+    public function setTdsBillCity($value)
+    {
+        return $this->setParameter('TDS_BILL_CITY', $value);
+    }
+
+    public function getTdsBillCountry()
+    {
+        return $this->getParameter('TDS_BILL_COUNTRY');
+    }
+
+    public function setTdsBillCountry($value)
+    {
+        return $this->setParameter('TDS_BILL_COUNTRY', $value);
+    }
+
+    public function getTdsBillAddress1()
+    {
+        return $this->getParameter('TDS_BILL_ADDRESS1');
+    }
+
+    public function setTdsBillAddress1($value)
+    {
+        return $this->setParameter('TDS_BILL_ADDRESS1', $value);
+    }
+
+    public function getTdsBillAddress2()
+    {
+        return $this->getParameter('TDS_BILL_ADDRESS2');
+    }
+
+    public function setTdsBillAddress2($value)
+    {
+        return $this->setParameter('TDS_BILL_ADDRESS2', $value);
+    }
+
+    public function getTdsBillZip()
+    {
+        return $this->getParameter('TDS_BILL_ZIP');
+    }
+
+    public function setTdsBillZip($value)
+    {
+        return $this->setParameter('TDS_BILL_ZIP', $value);
+    }
+
+    public function getTdsShipCity()
+    {
+        return $this->getParameter('TDS_SHIP_CITY');
+    }
+
+    public function setTdsShipCity($value)
+    {
+        return $this->setParameter('TDS_SHIP_CITY', $value);
+    }
+
+    public function getTdsShipCountry()
+    {
+        return $this->getParameter('TDS_SHIP_COUNTRY');
+    }
+
+    public function setTdsShipCountry($value)
+    {
+        return $this->setParameter('TDS_SHIP_COUNTRY', $value);
+    }
+
+    public function getTdsShipAddress1()
+    {
+        return $this->getParameter('TDS_SHIP_ADDRESS1');
+    }
+
+    public function setTdsShipAddress1($value)
+    {
+        return $this->setParameter('TDS_SHIP_ADDRESS1', $value);
+    }
+
+    public function getTdsShipAddress2()
+    {
+        return $this->getParameter('TDS_SHIP_ADDRESS2');
+    }
+
+    public function setTdsShipAddress2($value)
+    {
+        return $this->setParameter('TDS_SHIP_ADDRESS2', $value);
+    }
+
+    public function getTdsShipZip()
+    {
+        return $this->getParameter('TDS_SHIP_ZIP');
+    }
+
+    public function setTdsShipZip($value)
+    {
+        return $this->setParameter('TDS_SHIP_ZIP', $value);
+    }
+
+    public function getTdsAddrMatch()
+    {
+        return $this->getParameter('TDS_ADDR_MATCH');
+    }
+
+    public function setTdsAddrMatch($value)
+    {
+        return $this->setParameter('TDS_ADDR_MATCH', $value);
+    }
+
+    public function getData()
+    {
+        $this->validate('sharedSecret', 'mid', 'currency', 'vs', 'rurl', 'ipc', 'name', 'timestamp');
+
+        $data = [];
+        $data['PT'] = 'CardPay';
+
+        $data['MID'] = $this->getMid();
+        $data['AMT'] = $this->getAmount();
+        $data['CURR'] = (new ISOCurrencies())->numericCodeFor(new Currency($this->getCurrency()));
+        $data['VS'] = $this->getVs();
+        $data['RURL'] = $this->getRurl();
+        $data['IPC'] = $this->getIpc();
+        $data['NAME'] = $this->getName();
+        $data['TIMESTAMP'] = $this->getTimestamp();
+
+        $data['E2E'] = $this->getE2E();
+        $data['TXN'] = $this->getTxn();
+        $data['REM'] = $this->getRem();
+        $data['TPAY'] = $this->getTpay();
+        $data['CID'] = $this->getCid();
+        $data['ECID'] = $this->getEcid();
+
+        $data['TDS_CARDHOLDER'] = $this->getTdsCardholder();
+        $data['TDS_EMAIL'] = $this->getTdsEmail();
+        $data['TDS_MOBILE_PHONE'] = $this->getTdsMobilePhone();
+        $data['TDS_BILL_CITY'] = $this->getTdsBillCity();
+        $data['TDS_BILL_COUNTRY'] = $this->getTdsBillCountry();
+        $data['TDS_BILL_CITY'] = $this->getTdsBillCity();
+        $data['TDS_BILL_ADDRESS1'] = $this->getTdsBillAddress1();
+        $data['TDS_BILL_ADDRESS2'] = $this->getTdsBillAddress2();
+        $data['TDS_BILL_ZIP'] = $this->getTdsBillZip();
+        $data['TDS_BILL_CITY'] = $this->getTdsBillCity();
+        $data['TDS_SHIP_COUNTRY'] = $this->getTdsShipCountry();
+        $data['TDS_SHIP_ADDRESS1'] = $this->getTdsShipAddress1();
+        $data['TDS_SHIP_ADDRESS2'] = $this->getTdsShipAddress2();
+        $data['TDS_SHIP_ZIP'] = $this->getTdsShipZip();
+        $data['TDS_ADDR_MATCH'] = $this->getTdsAddrMatch();
+
+        $data['AREDIR'] = $this->getAredir();
+        $data['LANG'] = $this->getLang();
+
+        return $data;
+    }
+
+    public function generateSignature($data)
+    {
+        $sign = new HmacSign();
+        return $sign->sign($data, $this->getParameter('sharedSecret'));
+    }
+
+    public function sendData($data)
+    {
+        $curr = (new ISOCurrencies())->numericCodeFor(new Currency($this->getCurrency()));
+
+        $input = "{$this->getMid()}{$this->getAmount()}{$curr}{$this->getVs()}{$this->getE2E()}{$this->getTxn()}{$this->getRurl()}";
+        $input .= "{$this->getIpc()}{$this->getName()}{$this->getRem()}{$this->getTpay()}{$this->getCid()}{$this->getEcid()}";
+        $input .="{$this->getTdsCardholder()}{$this->getTdsEmail()}{$this->getTdsMobilePhone()}{$this->getTdsBillCity()}";
+        $input .= "{$this->getTdsBillCountry()}{$this->getTdsBillAddress1()}{$this->getTdsBillAddress2()}{$this->getTdsBillZip()}";
+        $input .= "{$this->getTdsShipCity()}{$this->getTdsShipCountry()}{$this->getTdsShipAddress1()}{$this->getTdsShipAddress2()}";
+        $input .= "{$this->getTdsShipZip()}{$this->getTdsAddrMatch()}{$this->getTimestamp()}";
+
+        $data['HMAC'] = $this->generateSignature($input);
+
+        return $this->response = new AuthorizeResponse($this, $data);
+    }
+
+    public function getEndpoint()
+    {
+        if ($this->getTestMode()) {
+            return 'https://platby.tomaj.sk/payment/cardpay-authorize-hmac';
+        }
+
+        return 'https://moja.tatrabanka.sk/cgi-bin/e-commerce/start/cardpay';
+    }
+}

--- a/src/CardPay/Message/AuthorizeResponse.php
+++ b/src/CardPay/Message/AuthorizeResponse.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Omnipay\CardPay\Message;
+
+use Omnipay\Common\Message\AbstractResponse;
+use Omnipay\Common\Message\RedirectResponseInterface;
+
+class AuthorizeResponse extends AbstractResponse implements RedirectResponseInterface
+{
+    public function isSuccessful()
+    {
+        return false;
+    }
+
+    public function isRedirect()
+    {
+        return true;
+    }
+
+    public function getRedirectUrl()
+    {
+        return $this->getRequest()->getEndpoint() . '?' . http_build_query($this->getRedirectData());
+    }
+
+    /**
+     * @return AuthorizeRequest
+     */
+    public function getRequest()
+    {
+        return $this->request;
+    }
+
+    public function getRedirectMethod()
+    {
+        return 'GET';
+    }
+
+    public function getRedirectData()
+    {
+        return $this->data;
+    }
+}

--- a/src/CardPay/Message/CancelAuthorizeRequest.php
+++ b/src/CardPay/Message/CancelAuthorizeRequest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Omnipay\CardPay\Message;
+
+use Omnipay\Common\Exception\InvalidResponseException;
+use Omnipay\Core\Message\AbstractRequest;
+use Omnipay\Core\Sign\HmacSign;
+use Tracy\Debugger;
+
+class CancelAuthorizeRequest extends AbstractRequest
+{
+    const TXN_CLOSE_PREAUTHORIZATION = 'CPA';
+    const TXN_STORNO_PREAUTHORIZATION = 'SPA';
+    const TXN_CHARGEBACK = 'CB';
+
+    public function initialize(array $parameters = [])
+    {
+        parent::initialize($parameters);
+        $this->setTimestamp(gmdate('dmYHis'));
+
+        return $this;
+    }
+
+    public function setTid($value)
+    {
+        return $this->setParameter('tid', $value);
+    }
+
+    public function getTid()
+    {
+        return $this->getParameter('tid');
+    }
+
+    public function setTxn($value)
+    {
+        if (!in_array($value, [static::TXN_STORNO_PREAUTHORIZATION, static::TXN_CLOSE_PREAUTHORIZATION, static::TXN_CHARGEBACK])) {
+            throw new \UnexpectedValueException("Unsopported value for TXN parameter: {$value}");
+        }
+
+        return $this->setParameter('txn', $value);
+    }
+
+    public function getTxn()
+    {
+        return $this->getParameter('txn');
+    }
+
+    public function getData()
+    {
+        $data = [];
+
+        $data['MID'] = $this->getMid();
+        $data['AMT'] = $this->getAmount();
+        $data['TID'] = $this->getTid();
+        $data['VS'] = $this->getVs();
+        $data['TXN'] = $this->getTxn();
+        $data['REM'] = $this->getRem();
+        $data['TIMESTAMP'] = $this->getTimestamp();
+
+        return $data;
+    }
+
+    private function generateSignature($data)
+    {
+        $sharedSecret = $this->getParameter('sharedSecret');
+
+        $sign = new HmacSign();
+        return $sign->sign($data, $sharedSecret);
+    }
+
+    public function sendData($data)
+    {
+        $input = "{$this->getMid()}{$this->getAmount()}{$this->getTid()}{$this->getVs()}{$this->getTxn()}{$this->getRem()}{$this->getTimestamp()}";
+        $data['HMAC'] = $this->generateSignature($input);
+
+        $params = http_build_query($data);
+
+        $client = $this->getHttpClient();
+        $response = $client->request(
+            'GET',
+            "{$this->getEndpoint()}?{$params}"
+        );
+
+        if ($response->getStatusCode() !== 200) {
+            throw new \Exception("Failed to request gateway: {$response->getStatusCode()} {$response->getReasonPhrase()}");
+        }
+
+        $xml = $response->getBody()->getContents();
+
+        $authorizationHeaders = $response->getHeader('Authorization');
+        if (is_array($authorizationHeaders) && !empty($authorizationHeaders)) {
+            $parsedHeaders = [];
+            foreach (explode(",", $authorizationHeaders[0]) as $part) {
+                $item = explode("=", $part);
+                $parsedHeaders[$item[0]] = $item[1];
+            }
+
+            if (isset($parsedHeaders['HMAC']) && $parsedHeaders['HMAC'] !== $this->generateSignature($xml)) {
+                throw new InvalidResponseException("Incorrect signature");
+            }
+        }
+
+        $simpleXmlElement = new \SimpleXMLElement($xml);
+
+        return $this->response = new CancelAuthorizeResponse($this, (array)$simpleXmlElement->result);
+    }
+
+    public function getEndpoint()
+    {
+        if ($this->getTestMode()) {
+            return 'https://platby.tomaj.sk/payment/cardpay-cancel-purchase';
+        }
+
+        return 'https://moja.tatrabanka.sk/cgi-bin/e-commerce/start/txn_process.jsp';
+    }
+}

--- a/src/CardPay/Message/CancelAuthorizeRequest.php
+++ b/src/CardPay/Message/CancelAuthorizeRequest.php
@@ -5,7 +5,6 @@ namespace Omnipay\CardPay\Message;
 use Omnipay\Common\Exception\InvalidResponseException;
 use Omnipay\Core\Message\AbstractRequest;
 use Omnipay\Core\Sign\HmacSign;
-use Tracy\Debugger;
 
 class CancelAuthorizeRequest extends AbstractRequest
 {
@@ -75,8 +74,7 @@ class CancelAuthorizeRequest extends AbstractRequest
 
         $params = http_build_query($data);
 
-        $client = $this->getHttpClient();
-        $response = $client->request(
+        $response = $this->httpClient->request(
             'GET',
             "{$this->getEndpoint()}?{$params}"
         );

--- a/src/CardPay/Message/CancelAuthorizeResponse.php
+++ b/src/CardPay/Message/CancelAuthorizeResponse.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Omnipay\CardPay\Message;
+
+use Omnipay\Common\Message\AbstractResponse;
+
+class CancelAuthorizeResponse extends AbstractResponse
+{
+    const SUCCESS = 'OK';
+
+    public function isSuccessful()
+    {
+        return $this->getRes() === self::SUCCESS;
+    }
+
+    public function getRes()
+    {
+        if (isset($this->data['RES'])) {
+            return $this->data['RES'];
+        }
+        return null;
+    }
+
+    public function getErrorCode()
+    {
+        if (isset($this->data['errorCode'])) {
+            return $this->data['errorCode'];
+        }
+        return null;
+    }
+}

--- a/src/CardPay/Message/CompleteAuthorizeRequest.php
+++ b/src/CardPay/Message/CompleteAuthorizeRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Omnipay\CardPay\Message;
+
+use Money\Currencies\ISOCurrencies;
+use Money\Currency;
+use Omnipay\Common\Exception\InvalidRequestException;
+use Omnipay\Core\Message\AbstractRequest;
+use Omnipay\Core\Sign\HmacSign;
+
+class CompleteAuthorizeRequest extends AbstractRequest
+{
+    public function getData()
+    {
+        $vs = isset($_GET['VS']) ? $_GET['VS'] : '';
+        $ac = isset($_GET['AC']) ? $_GET['AC'] : '';
+        $res = isset($_GET['RES']) ? $_GET['RES'] : '';
+        $tres = isset($_GET['TRES']) ? $_GET['TRES'] : '';
+        $tid = isset($_GET['TID']) ? $_GET['TID'] : '';
+        $cc = isset($_GET['CC']) ? $_GET['CC'] : '';
+        $rc = isset($_GET['RC']) ? $_GET['RC'] : '';
+        $txn = isset($_GET['TXN']) ? $_GET['TXN'] : '';
+        $cid = isset($_GET['CID']) ? $_GET['CID'] : '';
+        $timestamp = isset($_GET['TIMESTAMP']) ? $_GET['TIMESTAMP'] : '';
+
+        if ($vs != $this->getVs()) {
+            throw new InvalidRequestException('Variable symbol mismatch');
+        }
+
+        $curr = (new ISOCurrencies())->numericCodeFor(new Currency($this->getCurrency()));
+        $data = "{$this->getAmount()}{$curr}{$this->getVs()}{$txn}{$res}{$ac}{$tres}{$cid}{$cc}{$rc}{$tid}{$timestamp}";
+
+        $sign = new HmacSign();
+        if ($sign->sign($data, $this->getParameter('sharedSecret')) != $_GET['HMAC']) {
+            throw new InvalidRequestException('incorect signature');
+        }
+
+        return [
+            'RES' => $res,
+            'VS' => $vs,
+            'RC' => $rc,
+            'TRES' => $tres,
+            'TID' => $tid,
+            'CID' => $cid,
+        ];
+    }
+
+    public function sendData($data)
+    {
+        return $this->response = new CompleteAuthorizeResponse($this, $data);
+    }
+}

--- a/src/CardPay/Message/CompleteAuthorizeResponse.php
+++ b/src/CardPay/Message/CompleteAuthorizeResponse.php
@@ -61,5 +61,4 @@ class CompleteAuthorizeResponse extends AbstractResponse
 
         return null;
     }
-
 }

--- a/src/CardPay/Message/CompleteAuthorizeResponse.php
+++ b/src/CardPay/Message/CompleteAuthorizeResponse.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Omnipay\CardPay\Message;
+
+use Omnipay\Common\Message\AbstractResponse;
+
+class CompleteAuthorizeResponse extends AbstractResponse
+{
+    const SUCCESS = 'OK';
+
+    public function isSuccessful()
+    {
+        return static::SUCCESS === $this->getRes();
+    }
+
+    public function getRes()
+    {
+        if (isset($this->data['RES'])) {
+            return $this->data['RES'];
+        }
+        return null;
+    }
+
+    public function getVs()
+    {
+        if (isset($this->data['VS'])) {
+            return $this->data['VS'];
+        }
+        return null;
+    }
+
+    public function getRc()
+    {
+        if (isset($this->data['RC'])) {
+            return $this->data['RC'];
+        }
+        return null;
+    }
+
+    public function getTres()
+    {
+        if (isset($this->data['TRES'])) {
+            return $this->data['TRES'];
+        }
+        return null;
+    }
+
+    public function getCid()
+    {
+        if (isset($this->data['CID'])) {
+            return $this->data['CID'];
+        }
+        return null;
+    }
+
+    public function getTransactionReference()
+    {
+        if (isset($this->data['TID'])) {
+            return $this->data['TID'];
+        }
+
+        return null;
+    }
+
+}

--- a/src/CardPay/Message/CompletePurchaseResponse.php
+++ b/src/CardPay/Message/CompletePurchaseResponse.php
@@ -4,7 +4,6 @@ namespace Omnipay\CardPay\Message;
 
 use Omnipay\Common\Message\AbstractResponse;
 use Omnipay\Common\Message\RequestInterface;
-use Omnipay\Core\Message\AbstractRequest;
 
 class CompletePurchaseResponse extends AbstractResponse
 {
@@ -34,7 +33,7 @@ class CompletePurchaseResponse extends AbstractResponse
     public function getRc()
     {
         if (isset($this->data['RC'])) {
-            return $this->data['RC';]
+            return $this->data['RC'];
         }
         return null;
     }

--- a/src/ComfortPay/Message/CompletePurchaseResponse.php
+++ b/src/ComfortPay/Message/CompletePurchaseResponse.php
@@ -58,7 +58,7 @@ class CompletePurchaseResponse extends AbstractResponse
     public function getRc()
     {
         if (isset($this->data['RC'])) {
-            return $this->data['RC';]
+            return $this->data['RC'];
         }
         return null;
     }

--- a/src/Core/Message/AbstractRequest.php
+++ b/src/Core/Message/AbstractRequest.php
@@ -118,9 +118,14 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     {
         return $this->getParameter('rurl');
     }
-    
+
     public function setRurl($value)
     {
         return $this->setParameter('rurl', $value);
+    }
+
+    public function getHttpClient()
+    {
+        return $this->httpClient;
     }
 }

--- a/src/Core/Message/AbstractRequest.php
+++ b/src/Core/Message/AbstractRequest.php
@@ -123,9 +123,4 @@ abstract class AbstractRequest extends \Omnipay\Common\Message\AbstractRequest
     {
         return $this->setParameter('rurl', $value);
     }
-
-    public function getHttpClient()
-    {
-        return $this->httpClient;
-    }
 }

--- a/tests/CardPay/GatewayTest.php
+++ b/tests/CardPay/GatewayTest.php
@@ -106,4 +106,30 @@ class GatewayTest extends GatewayTestCase
             $response->getRedirectUrl()
         );
     }
+
+    public function testAuthorizeSignWithHmac()
+    {
+        $this->gateway->setSharedSecret('11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111');
+
+        $request = $this->gateway->authorize([
+            'amount' => '1.01',
+            'vs' => '0257430862',
+            'currency' => 'EUR',
+            'rurl' => 'http://return.sk',
+            'name' => 'test',
+            'tpay' => "Y",
+            'rem' => 'test@example.com',
+            'ipc' => '127.0.0.1',
+        ]);
+
+        $request->setTimestamp('01022021214520');
+
+        $response = $request->send();
+
+        $this->assertTrue($response->isRedirect());
+        $this->assertEquals(
+            'https://moja.tatrabanka.sk/cgi-bin/e-commerce/start/cardpay?PT=CardPay&MID=1111&AMT=1.01&CURR=978&VS=0257430862&RURL=http%3A%2F%2Freturn.sk&IPC=127.0.0.1&NAME=test&TIMESTAMP=01022021214520&TXN=PA&REM=test%40example.com&TPAY=Y&HMAC=a6ae350560717be53682d381ae3abc714f5d7f65bf64a98a94e9110b8e25fb1a',
+            $response->getRedirectUrl()
+        );
+    }
 }


### PR DESCRIPTION
 Added authorize method to allow make `authorization` payment and also method for stop/cancel/chargeback `authorization`. 

Based on actual documentation: https://www.tatrabanka.sk/cardpay/CardPay_technicka_prirucka_HMAC.pdf

New testing endpoints of `tomaj/payment-simulator` are used . (PR: https://github.com/tomaj/payment-simulator/pull/6)

cc @rootpd 