### PR TITLE
Small fixes for authorization calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+ - Added `CC`(card number) and `ac` (approval code) parameters into authorization response.
+
 ## [4.1.1]
  - Fixed duplicated recurrent charge. Upgrade ASAP from 4.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
  - Added `CC`(card number) and `ac` (approval code) parameters into authorization response.
+ - Fixed cancel authorization response check.
 
 ## [4.1.1]
  - Fixed duplicated recurrent charge. Upgrade ASAP from 4.1

--- a/src/CardPay/Message/CancelAuthorizeResponse.php
+++ b/src/CardPay/Message/CancelAuthorizeResponse.php
@@ -15,8 +15,8 @@ class CancelAuthorizeResponse extends AbstractResponse
 
     public function getRes()
     {
-        if (isset($this->data['RES'])) {
-            return $this->data['RES'];
+        if (isset($this->data['res'])) {
+            return $this->data['res'];
         }
         return null;
     }

--- a/src/CardPay/Message/CompleteAuthorizeRequest.php
+++ b/src/CardPay/Message/CompleteAuthorizeRequest.php
@@ -42,6 +42,8 @@ class CompleteAuthorizeRequest extends AbstractRequest
             'TRES' => $tres,
             'TID' => $tid,
             'CID' => $cid,
+            'CC' => $cc,
+            'AC' => $ac,
         ];
     }
 

--- a/src/CardPay/Message/CompleteAuthorizeResponse.php
+++ b/src/CardPay/Message/CompleteAuthorizeResponse.php
@@ -61,4 +61,22 @@ class CompleteAuthorizeResponse extends AbstractResponse
 
         return null;
     }
+
+    public function getCc()
+    {
+        if (isset($this->data['CC'])) {
+            return $this->data['CC'];
+        }
+
+        return null;
+    }
+
+    public function getAc()
+    {
+        if (isset($this->data['AC'])) {
+            return $this->data['AC'];
+        }
+
+        return null;
+    }
 }


### PR DESCRIPTION
Added `CC`(card number) and `ac` (approval code) parameters into authorization response.

Fixed cancel authorization response check.