### PR TITLE
Added data and sign to exception message in CardPay/CompletePurchaseRequest on incorrect hmac signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Added support for configurable host url in purchase request in test mode.
+- Added data and sign to `InvalidRequestException` message in CardPay `CompletePurchaseRequest` on incorrect hmac signature.
 
 ## [4.1.2]
 

--- a/src/CardPay/Message/CompletePurchaseRequest.php
+++ b/src/CardPay/Message/CompletePurchaseRequest.php
@@ -35,7 +35,7 @@ class CompletePurchaseRequest extends AbstractRequest
             $data = "{$this->getAmount()}{$curr}{$this->getVs()}{$res}{$ac}{$tres}{$cc}{$rc}{$tid}{$timestamp}";
             $sign = new HmacSign();
             if ($sign->sign($data, $sharedSecret) != $_GET['HMAC']) {
-                throw new InvalidRequestException('incorect signature');
+                throw new InvalidRequestException("incorrect signature for data: '{$data}', sign: '{$_GET['HMAC']}'");
             }
         } elseif (strlen($sharedSecret) == 64) {
             $data = "{$this->getVs()}{$res}{$ac}";


### PR DESCRIPTION
Added because of need to debug seemingly random HmacSign check fails, while processing email payments.

We already tried to log on higher level, but on revalidating HmacSing->sign passes. 

details: https://gitlab.projektn.sk/remp/crm/-/issues/1766

cc @rootpd 